### PR TITLE
Minor function creation typo in 04_mnist_basics

### DIFF
--- a/04_mnist_basics.ipynb
+++ b/04_mnist_basics.ipynb
@@ -2358,7 +2358,7 @@
     "Instead of trying to find the similarity between an image and an \"ideal image,\" we could instead look at each individual pixel and come up with a set of weights for each one, such that the highest weights are associated with those pixels most likely to be black for a particular category. For instance, pixels toward the bottom right are not very likely to be activated for a 7, so they should have a low weight for a 7, but they are likely to be activated for an 8, so they should have a high weight for an 8. This can be represented as a function and set of weight values for each possible category—for instance the probability of being the number 8:\n",
     "\n",
     "```\n",
-    "def pr_eight(x,w) = (x*w).sum()\n",
+    "def pr_eight(x,w): return (x*w).sum()\n",
     "```"
    ]
   },


### PR DESCRIPTION
Updated pr_eight function creation: "def pr_eight(x,w) ="  --> "def pr_eight(x,w): return"